### PR TITLE
Added tags, removed JSON. Closes #1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,10 +37,6 @@ if [[ $FORCE_UPLOAD == true ]]; then
     FORCE_UPLOAD="--force-upload"
 fi
 
-if [[ $USE_JSON == true ]]; then
-    USE_JSON="--use-json"
-fi
-
 if [[ -z "$CAPABILITIES" ]]; then
     CAPABILITIES="--capabilities CAPABILITY_IAM"
 else
@@ -72,5 +68,5 @@ echo "[default]
 output = text
 region = $AWS_REGION" > ~/.aws/config
 
-array=(aws cloudformation deploy --stack-name $AWS_STACK_NAME --template-file $TEMPLATE $PARAMETER_OVERRIDES $CAPABILITIES $ROLE_ARN $FORCE_UPLOAD --no-fail-on-empty-changeset)
+array=(aws cloudformation deploy --stack-name $AWS_STACK_NAME --template-file $TEMPLATE $PARAMETER_OVERRIDES $CAPABILITIES $ROLE_ARN $FORCE_UPLOAD $TAGS --no-fail-on-empty-changeset)
 eval $(echo ${array[@]})


### PR DESCRIPTION
TAGS was missing from the cfn deploy command, despite being available.

--use-json was deprecated and removed from cloudformation deploy. This has now been removed as an option.